### PR TITLE
Mark package as typed

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,3 +5,4 @@ include doc/*.rst
 include doc/*/*.rst
 include doc/conf.py
 include doc/Makefile
+include yadm/py.typed

--- a/setup.py
+++ b/setup.py
@@ -44,4 +44,5 @@ setup(
     ],
 
     packages=['yadm', 'yadm.aio', 'yadm.fields', 'yadm.fields.money'],
+    package_data={'yadm': ['py.typed']},
 )


### PR DESCRIPTION
## Summary
- add the ``py.typed`` marker file to the source tree and include it in built sdists
- ship the typing marker in installed wheels via ``package_data`` so type checkers can use yadm's annotations

## Testing
- pytest *(fails: requires a MongoDB server at localhost:27017)*

------
https://chatgpt.com/codex/tasks/task_b_68ceec60147083239433d8cd084be698