### PR TITLE
Improve typing for basic fields

### DIFF
--- a/yadm/fields/base.py
+++ b/yadm/fields/base.py
@@ -1,12 +1,20 @@
-"""
-Base classes for build database fields.
-"""
+"""Base classes and descriptors used to build fields."""
+from __future__ import annotations
+
 import functools
+from typing import TYPE_CHECKING, Any, Generic, Optional, TypeVar, Union, overload
 
 from yadm.exceptions import NotLoadedError
 from yadm.markers import AttributeNotSet
 from yadm.document_item import DocumentItemMixin
 from yadm.log_items import SetField, ChangeChild
+
+if TYPE_CHECKING:  # pragma: no cover - only used for typing
+    from yadm.documents import BaseDocument
+
+
+T = TypeVar("T")
+DocumentLike = Union["BaseDocument", DocumentItemMixin]
 
 
 def pass_null(method):
@@ -20,7 +28,7 @@ def pass_null(method):
     return wrapper
 
 
-class FieldDescriptor:
+class FieldDescriptor(Generic[T]):
     """ Base desctiptor for fields.
 
     .. py:attribute:: name
@@ -32,7 +40,7 @@ class FieldDescriptor:
     Field instance for this desctiptor
 
     """
-    def __init__(self, name, field):
+    def __init__(self, name: str, field: "Field[T]") -> None:
         self.name = name
         self.field = field
 
@@ -41,7 +49,19 @@ class FieldDescriptor:
         document_class_name = type(self.field.document_class).__name__
         return '<{} "{}.{}">'.format(class_name, document_class_name, self.name)
 
-    def __get__(self, instance, owner):
+    @overload
+    def __get__(self, instance: None, owner: type["BaseDocument"]) -> "Field[T]":
+        ...
+
+    @overload
+    def __get__(self, instance: DocumentLike, owner: type["BaseDocument"]) -> T:
+        ...
+
+    def __get__(
+        self,
+        instance: Optional[DocumentLike],
+        owner: type["BaseDocument"],
+    ) -> Union["Field[T]", T]:
         """ Get python value from document.
 
         1. Lookup in __cache__;
@@ -99,7 +119,7 @@ class FieldDescriptor:
         else:
             return self.field.get_if_attribute_not_set(instance)
 
-    def __set__(self, instance, value):
+    def __set__(self, instance: DocumentLike, value: T) -> None:
         """ Set value to document.
 
         1. Call Field.prepare_value for cast value;
@@ -153,14 +173,14 @@ class FieldDescriptor:
         else:
             raise TypeError("can't set field directly")  # pragma: no cover
 
-    def __delete__(self, instance):
+    def __delete__(self, instance: DocumentLike) -> None:
         """ Mark document's key as not set.
         """
         if not isinstance(instance, type):
             setattr(instance, self.name, AttributeNotSet)
 
 
-class Field:
+class Field(Generic[T]):
     """ Base field for all database fields.
 
     :param bool smart_null:
@@ -184,20 +204,39 @@ class Field:
         Name of field in document.
         Set in :py:meth:`contribute_to_class`.
     """
-    descriptor_class = FieldDescriptor
-    smart_null = False
-    document_class = None
-    name = None
+    descriptor_class: type[FieldDescriptor[Any]] = FieldDescriptor
+    smart_null: bool = False
+    document_class: Optional[type["BaseDocument"]] = None
+    name: Optional[str] = None
 
-    def __init__(self, smart_null=False):
+    def __init__(self, smart_null: bool = False) -> None:
         self.smart_null = smart_null
+
+    if TYPE_CHECKING:  # pragma: no cover - only for the type checker
+        @overload
+        def __get__(self, instance: None, owner: type["BaseDocument"]) -> FieldDescriptor[T]:
+            ...
+
+        @overload
+        def __get__(self, instance: DocumentLike, owner: type["BaseDocument"]) -> T:
+            ...
+
+        def __get__(
+            self,
+            instance: Optional[DocumentLike],
+            owner: type["BaseDocument"],
+        ) -> Union[FieldDescriptor[T], T]:
+            ...
+
+        def __set__(self, instance: DocumentLike, value: T) -> None:
+            ...
 
     def __repr__(self):
         class_name = type(self).__name__
         doc_class_name = self.document_class and self.document_class.__name__
         return '<{} "{}.{}">'.format(class_name, doc_class_name, self.name)
 
-    def contribute_to_class(self, document_class, name):
+    def contribute_to_class(self, document_class: type["BaseDocument"], name: str) -> None:
         """ Add field for document_class.
 
         :param MetaDocument document_class: document class for add
@@ -207,7 +246,7 @@ class Field:
         self.document_class.__fields__[name] = self
         setattr(document_class, name, self.descriptor_class(name, self))
 
-    def copy(self):  # pragma: no cover
+    def copy(self) -> "Field[Any]":  # pragma: no cover
         """ Return copy of field.
         """
         return self.__class__(
@@ -215,28 +254,28 @@ class Field:
             smart_null=self.smart_null,
         )
 
-    def get_default(self, document):
+    def get_default(self, document: DocumentLike):
         """ Return default value.
         """
         return AttributeNotSet
 
-    def get_if_not_loaded(self, document):
+    def get_if_not_loaded(self, document: DocumentLike):
         """ Call if field data marked as not loaded.
         """
         raise NotLoadedError(self, document)
 
-    def get_if_attribute_not_set(self, document):
+    def get_if_attribute_not_set(self, document: DocumentLike):
         """ Call if key not exist in document.
         """
         raise AttributeError("{!r} document has no attribute {!r}"
                              "".format(document.__class__.__name__, self.name))
 
-    def get_fake(self, document, faker, deep):  # pragma: no cover
+    def get_fake(self, document: DocumentLike, faker, deep):  # pragma: no cover
         """ Return fake data for testing.
         """
         return self.get_default(document)
 
-    def prepare_value(self, document, value):  # pragma: no cover
+    def prepare_value(self, document: DocumentLike, value):  # pragma: no cover
         """ The method is called when value is assigned for the attribute.
 
         :param BaseDocument document: document
@@ -249,7 +288,7 @@ class Field:
         """
         return value
 
-    def to_mongo(self, document, value):  # pragma: no cover
+    def to_mongo(self, document: DocumentLike, value):  # pragma: no cover
         """ Convert python value to mongo value.
 
         :param BaseDocument document: document
@@ -258,7 +297,7 @@ class Field:
         """
         return value
 
-    def from_mongo(self, document, value):  # pragma: no cover
+    def from_mongo(self, document: DocumentLike, value):  # pragma: no cover
         """ Convert mongo value to python value.
 
         :param BaseDocument document: document

--- a/yadm/fields/datetime.py
+++ b/yadm/fields/datetime.py
@@ -6,7 +6,7 @@ import pytz  # type: ignore[import-untyped]
 from yadm.fields.base import DefaultMixin, Field, pass_null
 
 
-class DatetimeField(DefaultMixin, Field):
+class DatetimeField(DefaultMixin, Field[datetime]):
     """ Field for time stamp.
 
     :param bool auto_now: datetime.now as default
@@ -66,7 +66,7 @@ class DatetimeField(DefaultMixin, Field):
         return cls._fix_timezone(value)
 
 
-class TimedeltaField(DefaultMixin, Field):
+class TimedeltaField(DefaultMixin, Field[timedelta]):
     def get_fake(self, document, faker, depth):
         return faker.time_delta()
 

--- a/yadm/fields/decimal.py
+++ b/yadm/fields/decimal.py
@@ -16,7 +16,7 @@ TDecimalInMongo = Union[Decimal, Decimal128, dict]
 TDecimal128able = Union[Decimal, Decimal128, str]
 
 
-class DecimalField(DefaultMixin, Field):
+class DecimalField(DefaultMixin, Field[Decimal]):
     """ Field for work with :class:`decimal.Decimal`.
 
     TODO: context in copy()
@@ -99,10 +99,13 @@ class DecimalField(DefaultMixin, Field):
             raise TypeError(value)
 
 
-class Decimal128Field(DefaultMixin, Field):
+class Decimal128Field(DefaultMixin, Field[Decimal128]):
     @pass_null
-    def prepare_value(self, document: BaseDocument,
-                      value: TDecimal128able) -> Decimal:
+    def prepare_value(
+        self,
+        document: BaseDocument,
+        value: TDecimal128able,
+    ) -> Decimal128:
         if isinstance(value, Decimal128):
             return value
         elif isinstance(value, (str, Decimal)):

--- a/yadm/fields/enum.py
+++ b/yadm/fields/enum.py
@@ -1,22 +1,32 @@
+from __future__ import annotations
+
+from enum import Enum
+from typing import Mapping, Optional, Sequence, TypeVar
+
 from yadm.fields.base import pass_null
 from yadm.fields.simple import SimpleField
 from yadm.markers import AttributeNotSet
 
 
-class EnumField(SimpleField):
+E = TypeVar("E", bound=Enum)
+
+
+class EnumField(SimpleField[E]):
     """ Field for enum.Enum .
     """
-    def __init__(self, enum, **kwargs):
+    def __init__(self, enum: type[E], **kwargs):
         self.type = enum
         super().__init__(**kwargs)
 
     def copy(self):
-        return self.__class__(self.type,
-                              smart_null=self.smart_null,
-                              default=self.default)
+        return self.__class__(
+            self.type,
+            smart_null=self.smart_null,
+            default=self.default,
+        )
 
     @pass_null
-    def to_mongo(self, document, value):
+    def to_mongo(self, document, value: E):
         return value.value
 
 
@@ -38,12 +48,18 @@ class EnumStateInvalidInitial(Exception):
         super().__init__(self.message)
 
 
-class EnumStateField(EnumField):
+class EnumStateField(EnumField[E]):
     """ Simple state machine with states are enum.Enum .
     """
-    rules = None
+    rules: Optional[Mapping[E, Sequence[E]]] = None
 
-    def __init__(self, enum, rules=None, start=AttributeNotSet, **kwargs):
+    def __init__(
+        self,
+        enum: type[E],
+        rules: Optional[Mapping[E, Sequence[E]]] = None,
+        start: E | type[AttributeNotSet] = AttributeNotSet,
+        **kwargs,
+    ):
         if 'default' not in kwargs:
             kwargs = {'default': start, **kwargs}
 
@@ -56,9 +72,12 @@ class EnumStateField(EnumField):
             raise ValueError("Rules list is empty")
 
     def copy(self):
-        return self.__class__(self.type, self.rules,
-                              smart_null=self.smart_null,
-                              default=self.default)
+        return self.__class__(
+            self.type,
+            self.rules,
+            smart_null=self.smart_null,
+            default=self.default,
+        )
 
     @pass_null
     def prepare_value(self, document, value):

--- a/yadm/fields/simple.py
+++ b/yadm/fields/simple.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from random import choice
-from typing import Any, ClassVar, Optional, Sequence, Type
+from typing import Any, ClassVar, Generic, Optional, Sequence, Type, TypeVar
 
 from bson import ObjectId
 
@@ -10,7 +10,10 @@ from yadm.fields.base import Field, DefaultMixin, pass_null
 from yadm.markers import AttributeNotSet
 
 
-class StaticField(Field):
+T = TypeVar("T")
+
+
+class StaticField(Field[Any]):
     """ Field for static data.
     """
     def __init__(self, data: Any):
@@ -51,13 +54,13 @@ class StaticField(Field):
             return self.data
 
 
-class SimpleField(DefaultMixin, Field):
+class SimpleField(DefaultMixin, Field[T], Generic[T]):
     """ Base field for simple types.
 
     :param default: default value
     :param set choices: set of possible values
     """
-    type: ClassVar[Optional[Type[Any]]] = None
+    type: ClassVar[Optional[Type[T]]] = None
 
     def __init__(
         self,
@@ -114,7 +117,7 @@ class SimpleField(DefaultMixin, Field):
                              "".format(value, self.choices))
 
 
-class ObjectIdField(SimpleField):
+class ObjectIdField(SimpleField[ObjectId]):
     """ Field for ObjectId.
 
     :param bool default_gen: generate default value if not set
@@ -139,7 +142,7 @@ class ObjectIdField(SimpleField):
         return self.__class__(default_gen=self.default_gen)
 
 
-class BooleanField(SimpleField):
+class BooleanField(SimpleField[bool]):
     """ Field for boolean values.
     """
     type = bool
@@ -148,7 +151,7 @@ class BooleanField(SimpleField):
         return faker.pybool()
 
 
-class IntegerField(SimpleField):
+class IntegerField(SimpleField[int]):
     """ Field for integer.
     """
     type = int
@@ -160,7 +163,7 @@ class IntegerField(SimpleField):
             return faker.pyint()
 
 
-class FloatField(SimpleField):
+class FloatField(SimpleField[float]):
     """ Field for float.
     """
     type = float
@@ -172,7 +175,7 @@ class FloatField(SimpleField):
             return faker.pyfloat()
 
 
-class StringField(SimpleField):
+class StringField(SimpleField[str]):
     """ Field for string.
     """
     type = str


### PR DESCRIPTION
## Summary
- add generic typing to the field descriptor and base field so descriptors expose the underlying value type during type checking
- parameterize simple, datetime, decimal and enum field implementations with their concrete value types for better mypy compatibility

## Testing
- pytest *(fails: requires MongoDB at localhost:27017)*

------
https://chatgpt.com/codex/tasks/task_b_68d004d890548323a75f1a325edaf716