### PR TITLE
Expand enum state rules container typing

### DIFF
--- a/yadm/aio/testing.py
+++ b/yadm/aio/testing.py
@@ -7,6 +7,7 @@ from typing import Any, Optional, Type, TypeVar, cast
 import pymongo
 from faker import Faker
 
+from yadm.database import BaseDatabase
 from yadm.documents import BaseDocument, Document, EmbeddedDocument
 from yadm.markers import AttributeNotSet, Marker
 from yadm.testing import DEFAULT_DEPTH
@@ -20,7 +21,7 @@ COUNTER: Counter[Any] = Counter()
 
 async def aio_create_fake(
     __document_class__: Type[TDocument],
-    __db__: Optional[Any] = None,
+    __db__: Optional[BaseDatabase] = None,
     __faker__: Optional[Faker] = None,
     *,
     __parent__: Optional[BaseDocument] = None,

--- a/yadm/document_item.py
+++ b/yadm/document_item.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Iterator, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, FrozenSet, Iterator, Optional, Union, cast
 
 from yadm.log_items import BaseLog, ChangeChild
 
@@ -35,7 +35,12 @@ class DocumentItemMixin:
     """
     __parent__: Optional[Union['DocumentItemMixin', 'BaseDocument']] = None
     __name__: Optional[Union[str, int]] = None
-    __log__: ItemLog
+    __log__: BaseLog
+
+    if TYPE_CHECKING:
+        __cache__: dict[str, Any]
+        __raw__: dict[str, Any]
+        __not_loaded__: FrozenSet[str]
 
     def __init__(self, *args, **kwargs):
         self.__log__ = ItemLog(self)

--- a/yadm/documents.py
+++ b/yadm/documents.py
@@ -1,7 +1,7 @@
 """Document abstractions used by the ORM."""
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, ClassVar, Dict, Generator, Optional, Union
+from typing import TYPE_CHECKING, Any, ClassVar, Dict, Generator, Optional, Union, cast
 
 from bson import ObjectId
 from faker import Faker
@@ -38,7 +38,7 @@ class MetaDocument(type):
                                 cls.__name__, attr))
 
             if isinstance(field, Field):
-                field.contribute_to_class(cls, attr)
+                field.contribute_to_class(cast(type['BaseDocument'], cls), attr)
             else:
                 setattr(cls, attr, field)
 
@@ -52,6 +52,7 @@ class BaseDocument(metaclass=MetaDocument):
     __raw__: Dict[str, Any]
     __cache__: Dict[str, Any]
     __not_loaded__: frozenset[str] = frozenset()
+    __log__: BaseLog
 
     def __init__(self,
                  *args,
@@ -75,6 +76,7 @@ class BaseDocument(metaclass=MetaDocument):
 
         self.__raw__ = {}
         self.__cache__ = {}
+        self.__log__ = BaseLog()
 
         for key, field in self.__fields__.items():
             if key in data:
@@ -144,13 +146,12 @@ class Document(BaseDocument):
         _id = getattr(self, '_id', '<new>')
         return '{}({})'.format(self.__class__.__name__, _id)
 
-    def __eq__(self, other: Union['Document', ObjectId]) -> bool:
+    def __eq__(self, other: object) -> bool:
         if isinstance(other, Document):
             return self.id == other.id
-        elif isinstance(other, ObjectId):
+        if isinstance(other, ObjectId):
             return self.id == other
-        else:
-            return False
+        return False
 
     def __hash__(self) -> int:
         return hash(self.id)

--- a/yadm/fields/base.py
+++ b/yadm/fields/base.py
@@ -249,10 +249,11 @@ class Field(Generic[T]):
     def copy(self) -> "Field[Any]":  # pragma: no cover
         """ Return copy of field.
         """
-        return self.__class__(
-            item_field=self.item_field,
-            smart_null=self.smart_null,
-        )
+        kwargs: dict[str, Any] = {'smart_null': self.smart_null}
+        if hasattr(self, 'item_field'):
+            kwargs['item_field'] = getattr(self, 'item_field')
+
+        return self.__class__(**kwargs)  # type: ignore[call-arg]
 
     def get_default(self, document: DocumentLike):
         """ Return default value.

--- a/yadm/fields/decimal.py
+++ b/yadm/fields/decimal.py
@@ -2,13 +2,12 @@
 """
 from decimal import Decimal, getcontext, Context
 from functools import reduce
-from typing import Union, Optional, Iterable
+from typing import Iterable, Optional, Union
 
 
 from bson import Decimal128
 
-from yadm.documents import BaseDocument
-from yadm.fields.base import Field, DefaultMixin, pass_null
+from yadm.fields.base import DocumentLike, Field, DefaultMixin, pass_null
 
 
 TDecimalable = Union[Decimal, Decimal128, str, int]
@@ -39,7 +38,7 @@ class DecimalField(DefaultMixin, Field[Decimal]):
     def context(self, context: Optional[Context]):
         self._context = context
 
-    def get_fake(self, document: BaseDocument, faker, depth):  # pragma: no cover
+    def get_fake(self, document: DocumentLike, faker, depth):  # pragma: no cover
         return faker.pydecimal()
 
     @staticmethod
@@ -51,7 +50,7 @@ class DecimalField(DefaultMixin, Field[Decimal]):
         return reduce(lambda cur, acc: cur * 10 + acc, digits, 0)
 
     @pass_null
-    def prepare_value(self, document: BaseDocument,
+    def prepare_value(self, document: DocumentLike,
                       value: TDecimalable) -> Decimal:
         """ Cast value to :class:`decimal.Decimal`.
         """
@@ -63,7 +62,7 @@ class DecimalField(DefaultMixin, Field[Decimal]):
             raise TypeError(value)
 
     @pass_null
-    def to_mongo(self, document: BaseDocument,
+    def to_mongo(self, document: DocumentLike,
                  value: Decimal) -> dict:
         sign, digits, exp = value.as_tuple()
         integer = self._integer_from_digits(digits)
@@ -73,7 +72,7 @@ class DecimalField(DefaultMixin, Field[Decimal]):
         }
 
     @pass_null
-    def from_mongo(self, document: BaseDocument,
+    def from_mongo(self, document: DocumentLike,
                    value: TDecimalInMongo) -> Decimal:
         if isinstance(value, dict):
             sign = value['i'] < 0  # False - positive, True - negative
@@ -103,7 +102,7 @@ class Decimal128Field(DefaultMixin, Field[Decimal128]):
     @pass_null
     def prepare_value(
         self,
-        document: BaseDocument,
+        document: DocumentLike,
         value: TDecimal128able,
     ) -> Decimal128:
         if isinstance(value, Decimal128):

--- a/yadm/fields/enum.py
+++ b/yadm/fields/enum.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Mapping, Optional, Sequence, TypeVar
+from typing import Container, Mapping, Optional, TypeVar
 
 from yadm.fields.base import pass_null
 from yadm.fields.simple import SimpleField
@@ -51,12 +51,12 @@ class EnumStateInvalidInitial(Exception):
 class EnumStateField(EnumField[E]):
     """ Simple state machine with states are enum.Enum .
     """
-    rules: Optional[Mapping[E, Sequence[E]]] = None
+    rules: Optional[Mapping[E, Container[E]]] = None
 
     def __init__(
         self,
         enum: type[E],
-        rules: Optional[Mapping[E, Sequence[E]]] = None,
+        rules: Optional[Mapping[E, Container[E]]] = None,
         start: E | type[AttributeNotSet] = AttributeNotSet,
         **kwargs,
     ):
@@ -89,8 +89,12 @@ class EnumStateField(EnumField[E]):
                 raise EnumStateInvalidInitial(new_value)
 
         else:
-            if (new_value != current_value and
-                    new_value not in self.rules.get(current_value, [])):
+            assert self.rules is not None
+            allowed = self.rules.get(current_value)
+            if (
+                new_value != current_value
+                and (allowed is None or new_value not in allowed)
+            ):
                 raise EnumStateSetError(current_value, new_value)
 
         return new_value

--- a/yadm/fields/references_list.py
+++ b/yadm/fields/references_list.py
@@ -40,7 +40,7 @@ from bson import ObjectId
 
 from yadm.documents import BaseDocument, Document, MetaDocument
 from yadm.document_item import DocumentItemMixin
-from yadm.fields.base import Field
+from yadm.fields.base import DocumentLike, Field
 from yadm.queryset import NotFoundBehavior
 
 
@@ -128,6 +128,13 @@ class ReferencesList(MutableSequence[Document], DocumentItemMixin):
             items=items,
         )
 
+    @staticmethod
+    def _extract_id(document: Document) -> ObjectId:
+        doc_id = document.id
+        if doc_id is None:
+            raise ValueError('Document must have an id')
+        return doc_id
+
     @overload
     def __getitem__(self, idx: int) -> Document:
         ...
@@ -152,7 +159,8 @@ class ReferencesList(MutableSequence[Document], DocumentItemMixin):
         self._check_resolved_and_rise()
         if isinstance(idx, slice):
             docs = list(document if isinstance(document, Iterable) else [document])
-            self._ids[idx] = [doc.id for doc in docs]
+            ids = [self._extract_id(doc) for doc in docs]
+            self._ids[idx] = ids
             self._documents[idx] = docs
             start_index = 0 if idx.start is None else idx.start
             for offset, doc in enumerate(docs):
@@ -161,7 +169,7 @@ class ReferencesList(MutableSequence[Document], DocumentItemMixin):
         else:
             if not isinstance(document, Document):
                 raise TypeError('document must be a Document instance')
-            self._ids[idx] = document.id
+            self._ids[idx] = self._extract_id(document)
             self._documents[idx] = document
             self.__log__.append(ReferencesListSetitem(index=idx, document=document))
 
@@ -213,13 +221,13 @@ class ReferencesList(MutableSequence[Document], DocumentItemMixin):
 
     def insert(self, idx: int, document: Document):
         self._check_resolved_and_rise()
-        self._ids.insert(idx, document.id)
+        self._ids.insert(idx, self._extract_id(document))
         self._documents.insert(idx, document)
         self.__log__.append(ReferencesListInsert(index=idx, document=document))
 
     def append(self, document: Document):
         self._check_resolved_and_rise()
-        self._ids.append(document.id)
+        self._ids.append(self._extract_id(document))
         self._documents.append(document)
         self.__log__.append(ReferencesListAppend(document=document))
 
@@ -279,7 +287,7 @@ class ReferencesListField(Field):
 
     def get_if_attribute_not_set(
         self,
-        document: Document,
+        document: DocumentLike,
     ) -> ReferencesList:  # pragma: no cover
         rl = ReferencesList(
             self._reference_document_class,
@@ -292,7 +300,7 @@ class ReferencesListField(Field):
         setattr(document, self.name, rl)
         return rl
 
-    def get_default(self, document: Document) -> ReferencesList:
+    def get_default(self, document: DocumentLike) -> ReferencesList:
         rl = ReferencesList(
             self._reference_document_class,
             [],
@@ -306,7 +314,7 @@ class ReferencesListField(Field):
 
     def prepare_value(
         self,
-        document: Document,
+        document: DocumentLike,
         value: Union[ReferencesList, List[Document]],
     ) -> ReferencesList:
         if isinstance(value, ReferencesList):
@@ -315,7 +323,7 @@ class ReferencesListField(Field):
             return value
 
         elif isinstance(value, list):
-            ids = [i.id for i in value]
+            ids = [ReferencesList._extract_id(i) for i in value]
             res = ReferencesList(
                 self._reference_document_class, ids,
                 field=self,
@@ -330,7 +338,7 @@ class ReferencesListField(Field):
 
     def from_mongo(
         self,
-        document: Document,
+        document: DocumentLike,
         value: List[ObjectId],
     ) -> ReferencesList:
         return ReferencesList(
@@ -340,6 +348,6 @@ class ReferencesListField(Field):
         )
 
     def to_mongo(self,
-                 document: Document,
+                 document: DocumentLike,
                  value: ReferencesList) -> List[ObjectId]:
         return value._ids

--- a/yadm/fields/simple.py
+++ b/yadm/fields/simple.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from random import choice
-from typing import Any, ClassVar, Generic, Optional, Sequence, Type, TypeVar
+from typing import Any, Generic, Optional, Sequence, TypeVar
 
 from bson import ObjectId
 
@@ -60,7 +60,7 @@ class SimpleField(DefaultMixin, Field[T], Generic[T]):
     :param default: default value
     :param set choices: set of possible values
     """
-    type: ClassVar[Optional[Type[T]]] = None
+    type: type[Any] | None = None
 
     def __init__(
         self,

--- a/yadm/testing.py
+++ b/yadm/testing.py
@@ -8,6 +8,7 @@ from typing import Any, Optional, Type, TypeVar, cast
 import pymongo
 from faker import Faker
 
+from yadm.database import BaseDatabase
 from yadm.documents import BaseDocument, Document, EmbeddedDocument
 from yadm.markers import AttributeNotSet, Marker
 
@@ -23,7 +24,7 @@ DEFAULT_DEPTH = 4  # <=450
 
 def create_fake(
     __document_class__: Type[TDocument],
-    __db__: Optional[pymongo.database.Database] = None,
+    __db__: Optional[BaseDatabase] = None,
     __faker__: Optional[Faker] = None,
     *,
     __parent__: Optional[BaseDocument] = None,
@@ -36,7 +37,7 @@ def create_fake(
 
     :param yadm.documents.BaseDocument __document_class__: document class
         for new instance
-    :param yadm.database.Database __db__: database instance
+    :param yadm.database.BaseDatabase __db__: database instance
         if specified, document and all references will be saved to database
     :param Faker __faker__: faker instance, create if not specified
     :param yadm.documents.BaseDocument __parent__: parent document


### PR DESCRIPTION
## Summary
- allow `EnumStateField` transition rules to accept any container of states and guard membership checks safely
- align simple field typing and document infrastructure so mypy recognizes document caches, logs, and database attributes
- tighten reference-list and decimal field annotations, ensuring document IDs are validated before use and fake helpers accept typed databases

## Testing
- mypy yadm/

------
https://chatgpt.com/codex/tasks/task_b_68d052586c20832385ec80f0a9ffe25d