### PR TITLE
Avoid circular import when loading testing helpers

### DIFF
--- a/yadm/testing.py
+++ b/yadm/testing.py
@@ -3,14 +3,16 @@ from __future__ import annotations
 
 from collections import Counter
 from types import GeneratorType
-from typing import Any, Optional, Type, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Optional, Type, TypeVar, cast
 
 import pymongo
 from faker import Faker
 
-from yadm.database import BaseDatabase
 from yadm.documents import BaseDocument, Document, EmbeddedDocument
 from yadm.markers import AttributeNotSet, Marker
+
+if TYPE_CHECKING:  # pragma: no cover - imported for type checking only
+    from yadm.database import BaseDatabase
 
 
 TDocument = TypeVar('TDocument', bound=BaseDocument)


### PR DESCRIPTION
## Summary
- gate the `BaseDatabase` import in `yadm.testing` behind a `TYPE_CHECKING` guard to avoid runtime circular dependencies

## Testing
- mypy yadm

------
https://chatgpt.com/codex/tasks/task_b_68d6ba86bc1c8323b395177f16c6633f